### PR TITLE
chore(deps): fix bun.lock after update

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,13 +5,13 @@
     "": {
       "name": "podcasts-i-listen-to",
       "dependencies": {
-        "@astrojs/vercel": "latest",
-        "astro": "latest",
+        "@astrojs/vercel": "^11.0.2",
+        "astro": "^7.0.6",
       },
       "devDependencies": {
-        "@tailwindcss/vite": "latest",
-        "tailwindcss": "latest",
-        "typescript": "latest",
+        "@tailwindcss/vite": "^4.3.2",
+        "tailwindcss": "^4.3.2",
+        "typescript": "^6.0.3",
       },
     },
   },


### PR DESCRIPTION
## Summary

Follow-up to #209. The previous merge included a `bun.lock` with `"latest"` strings in the root workspace dependencies block (a known `bun update --latest` quirk). This regenerates the lockfile from `package.json` so it records the resolved semver ranges.

## Testing

- [x] `bun install` produces this lockfile